### PR TITLE
Adding an encoder and decoder to the plugin setup's

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -521,7 +521,7 @@ TokenVotingTest
 │       │   └── It early support criterion is sharp by 1 vote
 │       └── When The number of casted votes is one shy of 100 participation 2
 │           └── It participation is not met with 1 vote missing
-└── Given Execution criteria handle token balances for multiple orders of magnitude
+└── Given Execution criteria multiple orders of magnitude
     ├── When Testing with a magnitude of 100
     │   └── It magnitudes of 10^0
     ├── When Testing with a magnitude of 101
@@ -579,11 +579,35 @@ TokenVotingSetupTest
 │   │   └── It returns the permissions expected for the update from build 2
 │   └── When Calling prepareUpdate for an update from build 3
 │       └── It returns the permissions expected for the update from build 3 (empty list)
-└── Given The context is prepareUninstallation
-    ├── When Calling prepareUninstallation and helpers contain a GovernanceWrappedERC20 token
-    │   └── It correctly returns permissions, when the required number of helpers is supplied
-    └── When Calling prepareUninstallation and helpers contain a GovernanceERC20 token
-        └── It correctly returns permissions, when the required number of helpers is supplied
+├── Given The context is prepareUninstallation
+│   ├── When Calling prepareUninstallation and helpers contain a GovernanceWrappedERC20 token
+│   │   └── It correctly returns permissions, when the required number of helpers is supplied
+│   └── When Calling prepareUninstallation and helpers contain a GovernanceERC20 token
+│       └── It correctly returns permissions, when the required number of helpers is supplied
+├── Given The installation parameters are defined
+│   ├── When Calling encodeInstallationParameters with the parameters
+│   │   └── It Should return the correct ABI-encoded byte representation
+│   └── When Calling decodeInstallationParameters with the encoded data
+│       └── It Should return the original installation parameters
+├── Given The installation request is for a new token // The token address in TokenSettings is address(0)
+│   └── When Calling prepareInstallation
+│       └── It Should return exactly 7 permissions to be granted, including one for minting
+├── Given The installation request is for an existing IVotescompliant token
+│   └── When Calling prepareInstallation 2
+│       └── It Should return exactly 6 permissions to be granted and NOT deploy a new token
+├── Given A plugin is being updated from a build version less than 3
+│   └── When Calling prepareUpdate with fromBuild  2
+│       ├── It Should return the initData for the update and a new VotingPowerCondition helper
+│       └── It Should return 5 permission changes (1 revoke and 4 grants)
+├── Given A plugin is being uninstalled
+│   └── When Calling prepareUninstallation
+│       └── It Should return exactly 6 permissions to be revoked
+├── Given A token contract that implements the IVotes interface functions
+│   └── When Calling supportsIVotesInterface with the tokens address
+│       └── It Should return true
+└── Given A token contract that does not implement the IVotes interface functions
+    └── When Calling supportsIVotesInterface with the tokens address 2
+        └── It Should return false
 ```
 ```
 UpgradingTest

--- a/src/TokenVotingSetup.sol
+++ b/src/TokenVotingSetup.sol
@@ -111,7 +111,6 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             IPlugin.TargetConfig memory targetConfig;
             uint256 minApprovals;
             bytes memory pluginMetadata;
-            address[] memory excludedAccounts;
 
             // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
             // and the required helpers

--- a/src/TokenVotingSetup.sol
+++ b/src/TokenVotingSetup.sol
@@ -102,65 +102,69 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
         external
         returns (address plugin, PreparedSetupData memory preparedSetupData)
     {
-        // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
-        // and the required helpers
-        (
-            MajorityVotingBase.VotingSettings memory votingSettings,
-            TokenSettings memory tokenSettings,
-            // only used for GovernanceERC20(token is not passed)
-            GovernanceERC20.MintSettings memory mintSettings,
-            IPlugin.TargetConfig memory targetConfig,
-            uint256 minApprovals,
-            bytes memory pluginMetadata
-        ) = abi.decode(
-            _data,
+        TokenSettings memory tokenSettings;
+        address token;
+
+        {
+            MajorityVotingBase.VotingSettings memory votingSettings;
+            GovernanceERC20.MintSettings memory mintSettings;
+            IPlugin.TargetConfig memory targetConfig;
+            uint256 minApprovals;
+            bytes memory pluginMetadata;
+            address[] memory excludedAccounts;
+
+            // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
+            // and the required helpers
             (
-                MajorityVotingBase.VotingSettings,
-                TokenSettings,
-                GovernanceERC20.MintSettings,
-                IPlugin.TargetConfig,
-                uint256,
-                bytes
-            )
-        );
+                votingSettings,
+                tokenSettings,
+                // only used for GovernanceERC20(token is not passed)
+                mintSettings,
+                targetConfig,
+                minApprovals,
+                pluginMetadata
+            ) = decodeInstallationParameters(_data);
 
-        address token = tokenSettings.addr;
+            token = tokenSettings.addr;
 
-        if (tokenSettings.addr != address(0)) {
-            if (!token.isContract()) {
-                revert TokenNotContract(token);
+            // Use the given token
+            if (token != address(0)) {
+                if (!token.isContract()) {
+                    revert TokenNotContract(token);
+                }
+
+                if (!_isERC20(token)) {
+                    revert TokenNotERC20(token);
+                }
+
+                if (!supportsIVotesInterface(token)) {
+                    token = governanceWrappedERC20Base.clone();
+
+                    // User already has a token. We need to wrap it in
+                    // GovernanceWrappedERC20 in order to make the token
+                    // include governance functionality.
+                    GovernanceWrappedERC20(token).initialize(
+                        IERC20Upgradeable(tokenSettings.addr), tokenSettings.name, tokenSettings.symbol
+                    );
+                }
+            } else {
+                // Create a new token: Clone a `GovernanceERC20`.
+                token = governanceERC20Base.clone();
+                GovernanceERC20(token).initialize(IDAO(_dao), tokenSettings.name, tokenSettings.symbol, mintSettings);
             }
 
-            if (!_isERC20(token)) {
-                revert TokenNotERC20(token);
-            }
+            // Prepare and deploy plugin proxy.
+            plugin = address(tokenVotingBase).deployUUPSProxy(
+                abi.encodeCall(
+                    TokenVoting.initialize,
+                    (IDAO(_dao), votingSettings, IVotesUpgradeable(token), targetConfig, minApprovals, pluginMetadata)
+                )
+            );
 
-            if (!supportsIVotesInterface(token)) {
-                token = governanceWrappedERC20Base.clone();
-                // User already has a token. We need to wrap it in
-                // GovernanceWrappedERC20 in order to make the token
-                // include governance functionality.
-                GovernanceWrappedERC20(token).initialize(
-                    IERC20Upgradeable(tokenSettings.addr), tokenSettings.name, tokenSettings.symbol
-                );
-            }
-        } else {
-            // Clone a `GovernanceERC20`.
-            token = governanceERC20Base.clone();
-            GovernanceERC20(token).initialize(IDAO(_dao), tokenSettings.name, tokenSettings.symbol, mintSettings);
+            preparedSetupData.helpers = new address[](2);
+            preparedSetupData.helpers[0] = address(new VotingPowerCondition(plugin));
+            preparedSetupData.helpers[1] = token;
         }
-
-        // Prepare and deploy plugin proxy.
-        plugin = address(tokenVotingBase).deployUUPSProxy(
-            abi.encodeCall(
-                TokenVoting.initialize,
-                (IDAO(_dao), votingSettings, IVotesUpgradeable(token), targetConfig, minApprovals, pluginMetadata)
-            )
-        );
-
-        preparedSetupData.helpers = new address[](2);
-        preparedSetupData.helpers[0] = address(new VotingPowerCondition(plugin));
-        preparedSetupData.helpers[1] = token;
 
         // Prepare permissions
         PermissionLib.MultiTargetPermission[] memory permissions =
@@ -349,6 +353,46 @@ contract TokenVotingSetup is PluginUpgradeableSetup {
             condition: PermissionLib.NO_CONDITION,
             permissionId: EXECUTE_PROPOSAL_PERMISSION_ID
         });
+    }
+
+    /// @notice Encodes the given installation parameters into a byte array
+    function encodeInstallationParameters(
+        MajorityVotingBase.VotingSettings memory votingSettings,
+        TokenSettings memory tokenSettings,
+        // only used for GovernanceERC20(token is not passed)
+        GovernanceERC20.MintSettings memory mintSettings,
+        IPlugin.TargetConfig memory targetConfig,
+        uint256 minApprovals,
+        bytes memory pluginMetadata
+    ) external pure returns (bytes memory) {
+        return abi.encode(votingSettings, tokenSettings, mintSettings, targetConfig, minApprovals, pluginMetadata);
+    }
+
+    /// @notice Decodes the given byte array into the original installation parameters
+    function decodeInstallationParameters(bytes memory _data)
+        public
+        pure
+        returns (
+            MajorityVotingBase.VotingSettings memory votingSettings,
+            TokenSettings memory tokenSettings,
+            // only used for GovernanceERC20(token is not passed)
+            GovernanceERC20.MintSettings memory mintSettings,
+            IPlugin.TargetConfig memory targetConfig,
+            uint256 minApprovals,
+            bytes memory pluginMetadata
+        )
+    {
+        return abi.decode(
+            _data,
+            (
+                MajorityVotingBase.VotingSettings,
+                TokenSettings,
+                GovernanceERC20.MintSettings,
+                IPlugin.TargetConfig,
+                uint256,
+                bytes
+            )
+        );
     }
 
     /// @notice Unsatisfiably determines if the token is an IVotes interface.

--- a/src/TokenVotingSetupZkSync.sol
+++ b/src/TokenVotingSetupZkSync.sol
@@ -96,7 +96,6 @@ contract TokenVotingSetupZkSync is PluginUpgradeableSetup {
             IPlugin.TargetConfig memory targetConfig;
             uint256 minApprovals;
             bytes memory pluginMetadata;
-            address[] memory excludedAccounts;
 
             // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
             // and the required helpers

--- a/src/TokenVotingSetupZkSync.sol
+++ b/src/TokenVotingSetupZkSync.sol
@@ -87,61 +87,63 @@ contract TokenVotingSetupZkSync is PluginUpgradeableSetup {
         external
         returns (address plugin, PreparedSetupData memory preparedSetupData)
     {
-        // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
-        // and the required helpers
-        (
-            MajorityVotingBase.VotingSettings memory votingSettings,
-            TokenSettings memory tokenSettings,
-            // only used for GovernanceERC20(token is not passed)
-            GovernanceERC20.MintSettings memory mintSettings,
-            IPlugin.TargetConfig memory targetConfig,
-            uint256 minApprovals,
-            bytes memory pluginMetadata
-        ) = abi.decode(
-            _data,
+        TokenSettings memory tokenSettings;
+        address token;
+
+        {
+            MajorityVotingBase.VotingSettings memory votingSettings;
+            GovernanceERC20.MintSettings memory mintSettings;
+            IPlugin.TargetConfig memory targetConfig;
+            uint256 minApprovals;
+            bytes memory pluginMetadata;
+            address[] memory excludedAccounts;
+
+            // Decode `_data` to extract the params needed for deploying and initializing `TokenVoting` plugin,
+            // and the required helpers
             (
-                MajorityVotingBase.VotingSettings,
-                TokenSettings,
-                GovernanceERC20.MintSettings,
-                IPlugin.TargetConfig,
-                uint256,
-                bytes
-            )
-        );
+                votingSettings,
+                tokenSettings,
+                // only used for GovernanceERC20(token is not passed)
+                mintSettings,
+                targetConfig,
+                minApprovals,
+                pluginMetadata
+            ) = decodeInstallationParameters(_data);
 
-        address token = tokenSettings.addr;
+            token = tokenSettings.addr;
 
-        if (tokenSettings.addr != address(0)) {
-            if (!token.isContract()) {
-                revert TokenNotContract(token);
+            if (token != address(0)) {
+                if (!token.isContract()) {
+                    revert TokenNotContract(token);
+                }
+
+                if (!_isERC20(token)) {
+                    revert TokenNotERC20(token);
+                }
+
+                if (!supportsIVotesInterface(token)) {
+                    token = address(
+                        new GovernanceWrappedERC20(
+                            IERC20Upgradeable(tokenSettings.addr), tokenSettings.name, tokenSettings.symbol
+                        )
+                    );
+                }
+            } else {
+                token = address(new GovernanceERC20(IDAO(_dao), tokenSettings.name, tokenSettings.symbol, mintSettings));
             }
 
-            if (!_isERC20(token)) {
-                revert TokenNotERC20(token);
-            }
+            // Prepare and deploy plugin proxy.
+            plugin = address(tokenVotingBase).deployUUPSProxy(
+                abi.encodeCall(
+                    TokenVoting.initialize,
+                    (IDAO(_dao), votingSettings, IVotesUpgradeable(token), targetConfig, minApprovals, pluginMetadata)
+                )
+            );
 
-            if (!supportsIVotesInterface(token)) {
-                token = address(
-                    new GovernanceWrappedERC20(
-                        IERC20Upgradeable(tokenSettings.addr), tokenSettings.name, tokenSettings.symbol
-                    )
-                );
-            }
-        } else {
-            token = address(new GovernanceERC20(IDAO(_dao), tokenSettings.name, tokenSettings.symbol, mintSettings));
+            preparedSetupData.helpers = new address[](2);
+            preparedSetupData.helpers[0] = address(new VotingPowerCondition(plugin));
+            preparedSetupData.helpers[1] = token;
         }
-
-        // Prepare and deploy plugin proxy.
-        plugin = address(tokenVotingBase).deployUUPSProxy(
-            abi.encodeCall(
-                TokenVoting.initialize,
-                (IDAO(_dao), votingSettings, IVotesUpgradeable(token), targetConfig, minApprovals, pluginMetadata)
-            )
-        );
-
-        preparedSetupData.helpers = new address[](2);
-        preparedSetupData.helpers[0] = address(new VotingPowerCondition(plugin));
-        preparedSetupData.helpers[1] = token;
 
         // Prepare permissions
         PermissionLib.MultiTargetPermission[] memory permissions =
@@ -330,6 +332,46 @@ contract TokenVotingSetupZkSync is PluginUpgradeableSetup {
             condition: PermissionLib.NO_CONDITION,
             permissionId: EXECUTE_PROPOSAL_PERMISSION_ID
         });
+    }
+
+    /// @notice Encodes the given installation parameters into a byte array
+    function encodeInstallationParameters(
+        MajorityVotingBase.VotingSettings memory votingSettings,
+        TokenSettings memory tokenSettings,
+        // only used for GovernanceERC20(token is not passed)
+        GovernanceERC20.MintSettings memory mintSettings,
+        IPlugin.TargetConfig memory targetConfig,
+        uint256 minApprovals,
+        bytes memory pluginMetadata
+    ) external pure returns (bytes memory) {
+        return abi.encode(votingSettings, tokenSettings, mintSettings, targetConfig, minApprovals, pluginMetadata);
+    }
+
+    /// @notice Decodes the given byte array into the original installation parameters
+    function decodeInstallationParameters(bytes memory _data)
+        public
+        pure
+        returns (
+            MajorityVotingBase.VotingSettings memory votingSettings,
+            TokenSettings memory tokenSettings,
+            // only used for GovernanceERC20(token is not passed)
+            GovernanceERC20.MintSettings memory mintSettings,
+            IPlugin.TargetConfig memory targetConfig,
+            uint256 minApprovals,
+            bytes memory pluginMetadata
+        )
+    {
+        return abi.decode(
+            _data,
+            (
+                MajorityVotingBase.VotingSettings,
+                TokenSettings,
+                GovernanceERC20.MintSettings,
+                IPlugin.TargetConfig,
+                uint256,
+                bytes
+            )
+        );
     }
 
     /// @notice Unsatisfiably determines if the token is an IVotes interface.

--- a/test/TokenVoting.t.sol
+++ b/test/TokenVoting.t.sol
@@ -1474,6 +1474,10 @@ contract TokenVotingTest is TestBase {
         assertTrue(plugin.isMinParticipationReached(proposalId));
     }
 
+    modifier givenExecutionCriteriaMultipleOrdersOfMagnitude() {
+        _;
+    }
+
     function _runMagnitudeTest(uint256 power) internal {
         uint256 baseUnit = 10 ** power;
         address[] memory holders = new address[](2);
@@ -1505,51 +1509,51 @@ contract TokenVotingTest is TestBase {
         assertTrue(plugin.canExecute(proposalId));
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_0() external {
+    function test_WhenTestingWithAMagnitudeOf100() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(0);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_1() external {
+    function test_WhenTestingWithAMagnitudeOf101() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(1);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_2() external {
+    function test_WhenTestingWithAMagnitudeOf102() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(2);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_3() external {
+    function test_WhenTestingWithAMagnitudeOf103() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(3);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_6() external {
+    function test_WhenTestingWithAMagnitudeOf106() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(6);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_12() external {
+    function test_WhenTestingWithAMagnitudeOf1012() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(12);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_18() external {
+    function test_WhenTestingWithAMagnitudeOf1018() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(18);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_24() external {
+    function test_WhenTestingWithAMagnitudeOf1024() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(24);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_36() external {
+    function test_WhenTestingWithAMagnitudeOf1036() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(36);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_48() external {
+    function test_WhenTestingWithAMagnitudeOf1048() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(48);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_60() external {
+    function test_WhenTestingWithAMagnitudeOf1060() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(60);
     }
 
-    function test_WhenTestingWithAMagnitudeOf10_66() external {
+    function test_WhenTestingWithAMagnitudeOf1066() external givenExecutionCriteriaMultipleOrdersOfMagnitude {
         _runMagnitudeTest(66);
     }
 }

--- a/test/TokenVoting.t.yaml
+++ b/test/TokenVoting.t.yaml
@@ -283,7 +283,7 @@ TokenVotingTest:
           - when: The number of casted votes is one shy of 100% participation
             then:
               - it: participation is not met with 1 vote missing
-  - given: Execution criteria handle token balances for multiple orders of magnitude
+  - given: "Execution criteria: multiple orders of magnitude"
     and:
       - when: Testing with a magnitude of 10^0
         then:

--- a/test/TokenVotingSetup.t.yaml
+++ b/test/TokenVotingSetup.t.yaml
@@ -54,3 +54,49 @@ TokenVotingSetupTest:
       - when: Calling prepareUninstallation and helpers contain a GovernanceERC20 token
         then:
           - it: correctly returns permissions, when the required number of helpers is supplied
+  - given: The installation parameters are defined
+    and:
+      - when: Calling encodeInstallationParameters() with the parameters
+        then:
+          - it: Should return the correct ABI-encoded byte representation
+      - when: Calling decodeInstallationParameters() with the encoded data
+        then:
+          - it: Should return the original installation parameters
+
+  - given: The installation request is for a new token
+    comment: The token address in TokenSettings is address(0)
+    and:
+      - when: Calling prepareInstallation()
+        then:
+          - it: Should return exactly 7 permissions to be granted, including one for minting
+
+  - given: The installation request is for an existing IVotes-compliant token
+    and:
+      - when: Calling prepareInstallation()
+        then:
+          - it: Should return exactly 6 permissions to be granted and NOT deploy a new token
+
+  - given: A plugin is being updated from a build version less than 3
+    and:
+      - when: Calling prepareUpdate() with _fromBuild = 2
+        then:
+          - it: Should return the initData for the update and a new VotingPowerCondition helper
+          - it: Should return 5 permission changes (1 revoke and 4 grants)
+
+  - given: A plugin is being uninstalled
+    and:
+      - when: Calling prepareUninstallation()
+        then:
+          - it: Should return exactly 6 permissions to be revoked
+
+  - given: A token contract that implements the IVotes interface functions
+    and:
+      - when: Calling supportsIVotesInterface() with the token's address
+        then:
+          - it: Should return true
+
+  - given: A token contract that does not implement the IVotes interface functions
+    and:
+      - when: Calling supportsIVotesInterface() with the token's address
+        then:
+          - it: Should return false

--- a/test/TokenVotingSetupZkSync.t.sol
+++ b/test/TokenVotingSetupZkSync.t.sol
@@ -1,0 +1,1165 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.28;
+
+import {TestBase} from "./lib/TestBase.sol";
+
+import {SimpleBuilder} from "./builders/SimpleBuilder.sol";
+import {TokenVotingSetupZkSync as PluginSetupContract} from "../src/TokenVotingSetupZkSync.sol";
+import {TokenVoting} from "../src/TokenVoting.sol";
+import {MajorityVotingBase} from "../src/base/MajorityVotingBase.sol";
+import {GovernanceERC20} from "../src/erc20/GovernanceERC20.sol";
+import {GovernanceWrappedERC20} from "../src/erc20/GovernanceWrappedERC20.sol";
+import {ERC20Mock} from "./mocks/ERC20Mock.sol";
+import {DAO} from "@aragon/osx/core/dao/DAO.sol";
+import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
+import {PermissionLib} from "@aragon/osx-commons-contracts/src/permission/PermissionLib.sol";
+import {IPlugin} from "@aragon/osx-commons-contracts/src/plugin/IPlugin.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {IVotesUpgradeable} from "@openzeppelin/contracts-upgradeable/governance/utils/IVotesUpgradeable.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+
+contract TokenVotingSetupZkSyncTest is TestBase {
+    // Permission IDs
+    bytes32 constant UPDATE_VOTING_SETTINGS_PERMISSION_ID = keccak256("UPDATE_VOTING_SETTINGS_PERMISSION");
+    bytes32 constant CREATE_PROPOSAL_PERMISSION_ID = keccak256("CREATE_PROPOSAL_PERMISSION");
+    bytes32 constant EXECUTE_PROPOSAL_PERMISSION_ID = keccak256("EXECUTE_PROPOSAL_PERMISSION");
+    bytes32 constant MINT_PERMISSION_ID = keccak256("MINT_PERMISSION");
+    bytes32 constant SET_METADATA_PERMISSION_ID = keccak256("SET_METADATA_PERMISSION");
+    bytes32 constant SET_TARGET_CONFIG_PERMISSION_ID = keccak256("SET_TARGET_CONFIG_PERMISSION");
+
+    address private constant ANY_ADDR = address(type(uint160).max);
+
+    PluginSetupContract internal pluginSetup;
+    GovernanceERC20 internal governanceERC20Base;
+    GovernanceWrappedERC20 internal governanceWrappedERC20Base;
+    DAO internal dao;
+
+    // Default settings
+    MajorityVotingBase.VotingSettings internal defaultVotingSettings;
+    PluginSetupContract.TokenSettings internal defaultTokenSettings;
+    GovernanceERC20.MintSettings internal defaultMintSettings;
+    IPlugin.TargetConfig internal defaultTargetConfig;
+    uint256 internal defaultMinApproval;
+    bytes internal defaultMetadata;
+
+    function setUp() public {
+        // Deploy DAO
+        (dao,,,) = new SimpleBuilder().withDaoOwner(address(this)).build();
+
+        // Deploy PluginSetup
+        pluginSetup = new PluginSetupContract();
+
+        // Default settings
+        defaultVotingSettings = MajorityVotingBase.VotingSettings({
+            votingMode: MajorityVotingBase.VotingMode.EarlyExecution,
+            supportThreshold: 500_000,
+            minParticipation: 200_000,
+            minDuration: 1 hours,
+            minProposerVotingPower: 0
+        });
+        defaultTokenSettings = PluginSetupContract.TokenSettings({addr: address(0), name: "MyToken", symbol: "TKN"});
+        defaultMintSettings = GovernanceERC20.MintSettings({receivers: new address[](0), amounts: new uint256[](0)});
+        defaultTargetConfig = IPlugin.TargetConfig({target: address(dao), operation: IPlugin.Operation.Call});
+        defaultMinApproval = 300_000;
+        defaultMetadata = "0x11";
+    }
+
+    function _getInstallationData() internal view returns (bytes memory) {
+        return abi.encode(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+    }
+
+    function _assertPermission(
+        PermissionLib.MultiTargetPermission memory p,
+        PermissionLib.Operation op,
+        address where,
+        address who,
+        address condition,
+        bytes32 permissionId
+    ) internal pure {
+        assertEq(uint8(p.operation), uint8(op), "permission op mismatch");
+        assertEq(p.where, where, "permission where mismatch");
+        assertEq(p.who, who, "permission who mismatch");
+        assertEq(p.condition, condition, "permission condition mismatch");
+        assertEq(p.permissionId, permissionId, "permissionId mismatch");
+    }
+
+    function test_WhenCallingSupportsInterface0xffffffff() external view {
+        // It does not support the empty interface
+        assertFalse(pluginSetup.supportsInterface(0xffffffff));
+    }
+
+    modifier givenTheContextIsPrepareInstallation() {
+        _;
+    }
+
+    function test_WhenCallingPrepareInstallationWithDataThatIsEmptyOrNotOfMinimumLength()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        // It fails if data is empty, or not of minimum length
+        vm.expectRevert();
+        pluginSetup.prepareInstallation(address(dao), "");
+
+        vm.expectRevert();
+        pluginSetup.prepareInstallation(address(dao), "0x1234");
+
+        // And it should not revert with correct data
+        pluginSetup.prepareInstallation(address(dao), _getInstallationData());
+    }
+
+    function test_WhenCallingPrepareInstallationIfMintSettingsArraysDoNotHaveTheSameLength()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        // It fails if `MintSettings` arrays do not have the same length
+        defaultMintSettings.receivers = new address[](1);
+        defaultMintSettings.amounts = new uint256[](0);
+
+        vm.expectRevert(abi.encodeWithSelector(GovernanceERC20.MintSettingsArrayLengthMismatch.selector, 1, 0));
+        pluginSetup.prepareInstallation(address(dao), _getInstallationData());
+    }
+
+    function test_WhenCallingPrepareInstallationIfPassedTokenAddressIsNotAContract()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        // It fails if passed token address is not a contract
+        defaultTokenSettings.addr = alice; // EOA is not a contract
+
+        vm.expectRevert(abi.encodeWithSelector(PluginSetupContract.TokenNotContract.selector, alice));
+        pluginSetup.prepareInstallation(address(dao), _getInstallationData());
+    }
+
+    function test_WhenCallingPrepareInstallationIfPassedTokenAddressIsNotERC20()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        // It fails if passed token address is not ERC20
+        defaultTokenSettings.addr = address(dao); // DAO is a contract but not ERC20
+
+        vm.expectRevert(abi.encodeWithSelector(PluginSetupContract.TokenNotERC20.selector, address(dao)));
+        pluginSetup.prepareInstallation(address(dao), _getInstallationData());
+    }
+
+    function test_WhenCallingPrepareInstallationAndAnERC20TokenAddressIsSupplied()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        // It correctly returns plugin, helpers and permissions, when an ERC20 token address is supplied
+        ERC20Mock erc20 = new ERC20Mock("Mock Token", "MTK");
+        defaultTokenSettings.addr = address(erc20);
+        bytes memory data = _getInstallationData();
+
+        uint256 nonce = vm.getNonce(address(pluginSetup));
+        address anticipatedWrappedTokenAddress = vm.computeCreateAddress(address(pluginSetup), nonce);
+        address anticipatedPluginAddress = vm.computeCreateAddress(address(pluginSetup), nonce + 1);
+        address anticipatedCondition = vm.computeCreateAddress(address(pluginSetup), nonce + 2);
+
+        (address plugin, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), data);
+
+        assertEq(plugin, anticipatedPluginAddress);
+        assertEq(prepared.helpers.length, 2);
+        assertEq(prepared.helpers[0], anticipatedCondition);
+        assertEq(prepared.helpers[1], anticipatedWrappedTokenAddress);
+
+        assertEq(prepared.permissions.length, 6);
+        _assertPermission(
+            prepared.permissions[0],
+            PermissionLib.Operation.Grant,
+            plugin,
+            address(dao),
+            address(0),
+            TokenVoting(plugin).UPDATE_VOTING_SETTINGS_PERMISSION_ID()
+        );
+        _assertPermission(
+            prepared.permissions[1],
+            PermissionLib.Operation.Grant,
+            address(dao),
+            plugin,
+            address(0),
+            dao.EXECUTE_PERMISSION_ID()
+        );
+        _assertPermission(
+            prepared.permissions[2],
+            PermissionLib.Operation.GrantWithCondition,
+            plugin,
+            ANY_ADDR,
+            anticipatedCondition,
+            TokenVoting(plugin).CREATE_PROPOSAL_PERMISSION_ID()
+        );
+        _assertPermission(
+            prepared.permissions[3],
+            PermissionLib.Operation.Grant,
+            plugin,
+            address(dao),
+            address(0),
+            TokenVoting(plugin).SET_TARGET_CONFIG_PERMISSION_ID()
+        );
+        _assertPermission(
+            prepared.permissions[4],
+            PermissionLib.Operation.Grant,
+            plugin,
+            address(dao),
+            address(0),
+            TokenVoting(plugin).SET_METADATA_PERMISSION_ID()
+        );
+        _assertPermission(
+            prepared.permissions[5],
+            PermissionLib.Operation.Grant,
+            plugin,
+            ANY_ADDR,
+            address(0),
+            TokenVoting(plugin).EXECUTE_PROPOSAL_PERMISSION_ID()
+        );
+    }
+
+    function test_WhenCallingPrepareInstallationAndAnERC20TokenAddressIsSupplied2()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        // It correctly sets up `GovernanceWrappedERC20` helper, when an ERC20 token address is supplied
+        ERC20Mock erc20 = new ERC20Mock("Mock Token", "MTK");
+        defaultTokenSettings.addr = address(erc20);
+        defaultTokenSettings.name = "My Wrapped Token";
+        defaultTokenSettings.symbol = "wTKN";
+
+        (, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), _getInstallationData());
+
+        GovernanceWrappedERC20 wrappedToken = GovernanceWrappedERC20(prepared.helpers[1]);
+
+        assertEq(wrappedToken.name(), "My Wrapped Token");
+        assertEq(wrappedToken.symbol(), "wTKN");
+        assertEq(address(wrappedToken.underlying()), address(erc20));
+        assertTrue(wrappedToken.supportsInterface(type(IVotesUpgradeable).interfaceId));
+    }
+
+    function test_WhenCallingPrepareInstallationAndAGovernanceTokenAddressIsSupplied()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        // It correctly returns plugin, helpers and permissions, when a governance token address is supplied
+        GovernanceERC20 govToken = new GovernanceERC20(IDAO(address(dao)), "Test", "TST", defaultMintSettings);
+        defaultTokenSettings.addr = address(govToken);
+        bytes memory data = _getInstallationData();
+
+        uint256 nonce = vm.getNonce(address(pluginSetup));
+        address anticipatedPluginAddress = vm.computeCreateAddress(address(pluginSetup), nonce);
+        address anticipatedCondition = vm.computeCreateAddress(address(pluginSetup), nonce + 1);
+
+        (address plugin, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), data);
+
+        assertEq(plugin, anticipatedPluginAddress);
+        assertEq(prepared.helpers.length, 2);
+        assertEq(prepared.helpers[0], anticipatedCondition);
+        assertEq(prepared.helpers[1], address(govToken));
+        assertEq(prepared.permissions.length, 6);
+    }
+
+    function test_WhenCallingPrepareInstallationAndATokenAddressIsNotSupplied()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        // It correctly returns plugin, helpers and permissions, when a token address is not supplied
+        defaultTokenSettings.addr = address(0);
+        bytes memory data = _getInstallationData();
+
+        uint256 nonce = vm.getNonce(address(pluginSetup));
+        address anticipatedTokenAddress = vm.computeCreateAddress(address(pluginSetup), nonce);
+        address anticipatedPluginAddress = vm.computeCreateAddress(address(pluginSetup), nonce + 1);
+        address anticipatedCondition = vm.computeCreateAddress(address(pluginSetup), nonce + 2);
+
+        (address plugin, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), data);
+
+        assertEq(plugin, anticipatedPluginAddress);
+        assertEq(prepared.helpers.length, 2);
+        assertEq(prepared.helpers[0], anticipatedCondition);
+        assertEq(prepared.helpers[1], anticipatedTokenAddress);
+
+        assertEq(prepared.permissions.length, 7);
+        _assertPermission(
+            prepared.permissions[6],
+            PermissionLib.Operation.Grant,
+            anticipatedTokenAddress,
+            address(dao),
+            address(0),
+            MINT_PERMISSION_ID
+        );
+    }
+
+    function test_WhenCallingPrepareInstallationAndATokenAddressIsNotPassed()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        // It correctly sets up the plugin and helpers, when a token address is not passed
+        defaultTokenSettings.addr = address(0);
+        (address pluginAddr, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), _getInstallationData());
+
+        TokenVoting plugin = TokenVoting(pluginAddr);
+        GovernanceERC20 token = GovernanceERC20(prepared.helpers[1]);
+
+        assertEq(address(plugin.dao()), address(dao));
+        assertEq(uint8(plugin.votingMode()), uint8(defaultVotingSettings.votingMode));
+        assertEq(address(plugin.getVotingToken()), address(token));
+        address target = plugin.getTargetConfig().target;
+        assertEq(target, defaultTargetConfig.target);
+        assertEq(address(token.dao()), address(dao));
+        assertEq(token.name(), defaultTokenSettings.name);
+        assertEq(token.symbol(), defaultTokenSettings.symbol);
+    }
+
+    modifier givenTheContextIsPrepareUpdate() {
+        _;
+    }
+
+    function test_WhenCallingPrepareUpdateForAnUpdateFromBuild1() external givenTheContextIsPrepareUpdate {
+        // It returns the permissions expected for the update from build 1
+        TokenVoting plugin;
+        (dao, plugin,,) = new SimpleBuilder().build();
+
+        bytes memory updateInnerData =
+            abi.encode(uint256(0), IPlugin.TargetConfig(address(0), IPlugin.Operation.Call), "");
+        IPluginSetup.SetupPayload memory updatePayload = IPluginSetup.SetupPayload({
+            plugin: address(plugin),
+            currentHelpers: new address[](2),
+            data: updateInnerData
+        });
+
+        uint256 nonce = vm.getNonce(address(pluginSetup));
+        address anticipatedCondition = vm.computeCreateAddress(address(pluginSetup), nonce);
+
+        (bytes memory initData, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareUpdate(address(dao), 1, updatePayload);
+
+        assertEq(initData, abi.encodeWithSelector(TokenVoting.initializeFrom.selector, 1, updateInnerData));
+        assertEq(prepared.helpers.length, 1);
+        assertEq(prepared.helpers[0], anticipatedCondition);
+        assertEq(prepared.permissions.length, 5);
+
+        _assertPermission(
+            prepared.permissions[0],
+            PermissionLib.Operation.Revoke,
+            address(plugin),
+            address(dao),
+            address(0),
+            keccak256("UPGRADE_PLUGIN_PERMISSION")
+        );
+        _assertPermission(
+            prepared.permissions[1],
+            PermissionLib.Operation.GrantWithCondition,
+            address(plugin),
+            ANY_ADDR,
+            anticipatedCondition,
+            keccak256("CREATE_PROPOSAL_PERMISSION")
+        );
+        _assertPermission(
+            prepared.permissions[2],
+            PermissionLib.Operation.Grant,
+            address(plugin),
+            address(dao),
+            address(0),
+            keccak256("SET_TARGET_CONFIG_PERMISSION")
+        );
+        _assertPermission(
+            prepared.permissions[3],
+            PermissionLib.Operation.Grant,
+            address(plugin),
+            address(dao),
+            address(0),
+            keccak256("SET_METADATA_PERMISSION")
+        );
+        _assertPermission(
+            prepared.permissions[4],
+            PermissionLib.Operation.Grant,
+            address(plugin),
+            ANY_ADDR,
+            address(0),
+            keccak256("EXECUTE_PROPOSAL_PERMISSION")
+        );
+    }
+
+    function test_WhenCallingPrepareUpdateForAnUpdateFromBuild2() external givenTheContextIsPrepareUpdate {
+        // It returns the permissions expected for the update from build 2
+        TokenVoting plugin;
+        (dao, plugin,,) = new SimpleBuilder().build();
+
+        uint256 nonce = vm.getNonce(address(pluginSetup));
+        address anticipatedCondition = vm.computeCreateAddress(address(pluginSetup), nonce);
+
+        bytes memory updateInnerData =
+            abi.encode(uint256(0), IPlugin.TargetConfig(address(0), IPlugin.Operation.Call), "");
+        IPluginSetup.SetupPayload memory updatePayload = IPluginSetup.SetupPayload({
+            plugin: address(plugin),
+            currentHelpers: new address[](2),
+            data: updateInnerData
+        });
+
+        (bytes memory initData, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareUpdate(address(dao), 2, updatePayload);
+
+        assertEq(initData, abi.encodeWithSelector(TokenVoting.initializeFrom.selector, 2, updateInnerData));
+        assertEq(prepared.permissions.length, 5);
+
+        _assertPermission(
+            prepared.permissions[0],
+            PermissionLib.Operation.Revoke,
+            address(plugin),
+            address(dao),
+            address(0),
+            keccak256("UPGRADE_PLUGIN_PERMISSION")
+        );
+        _assertPermission(
+            prepared.permissions[1],
+            PermissionLib.Operation.GrantWithCondition,
+            address(plugin),
+            ANY_ADDR,
+            anticipatedCondition,
+            keccak256("CREATE_PROPOSAL_PERMISSION")
+        );
+        _assertPermission(
+            prepared.permissions[2],
+            PermissionLib.Operation.Grant,
+            address(plugin),
+            address(dao),
+            address(0),
+            keccak256("SET_TARGET_CONFIG_PERMISSION")
+        );
+        _assertPermission(
+            prepared.permissions[3],
+            PermissionLib.Operation.Grant,
+            address(plugin),
+            address(dao),
+            address(0),
+            keccak256("SET_METADATA_PERMISSION")
+        );
+        _assertPermission(
+            prepared.permissions[4],
+            PermissionLib.Operation.Grant,
+            address(plugin),
+            ANY_ADDR,
+            address(0),
+            keccak256("EXECUTE_PROPOSAL_PERMISSION")
+        );
+    }
+
+    function test_WhenCallingPrepareUpdateForAnUpdateFromBuild3() external givenTheContextIsPrepareUpdate {
+        // It returns the permissions expected for the update from build 3 (empty list)
+        address pluginAddr = makeAddr("plugin");
+        bytes memory updateInnerData =
+            abi.encode(uint256(0), IPlugin.TargetConfig(address(0), IPlugin.Operation.Call), "");
+        IPluginSetup.SetupPayload memory updatePayload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: new address[](2), data: updateInnerData});
+
+        (bytes memory initData, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareUpdate(address(dao), 3, updatePayload);
+
+        assertEq(initData.length, 0);
+        assertEq(prepared.helpers.length, 0);
+        assertEq(prepared.permissions.length, 0);
+    }
+
+    modifier givenTheContextIsPrepareUninstallation() {
+        _;
+    }
+
+    function test_WhenCallingPrepareUninstallationAndHelpersContainAGovernanceWrappedERC20Token()
+        external
+        givenTheContextIsPrepareUninstallation
+    {
+        // It correctly returns permissions, when the required number of helpers is supplied
+        address pluginAddr = makeAddr("plugin");
+        address conditionAddr = makeAddr("condition");
+        GovernanceWrappedERC20 wrappedToken =
+            new GovernanceWrappedERC20(IERC20Upgradeable(makeAddr("underlying")), "W", "W");
+
+        address[] memory helpers = new address[](2);
+        helpers[0] = conditionAddr;
+        helpers[1] = address(wrappedToken);
+
+        IPluginSetup.SetupPayload memory payload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: helpers, data: ""});
+
+        PermissionLib.MultiTargetPermission[] memory permissions =
+            pluginSetup.prepareUninstallation(address(dao), payload);
+
+        assertEq(permissions.length, 6);
+        _assertPermission(
+            permissions[0],
+            PermissionLib.Operation.Revoke,
+            pluginAddr,
+            address(dao),
+            address(0),
+            UPDATE_VOTING_SETTINGS_PERMISSION_ID
+        );
+        _assertPermission(
+            permissions[1],
+            PermissionLib.Operation.Revoke,
+            address(dao),
+            pluginAddr,
+            address(0),
+            dao.EXECUTE_PERMISSION_ID()
+        );
+        _assertPermission(
+            permissions[2],
+            PermissionLib.Operation.Revoke,
+            pluginAddr,
+            address(dao),
+            address(0),
+            SET_TARGET_CONFIG_PERMISSION_ID
+        );
+        _assertPermission(
+            permissions[3],
+            PermissionLib.Operation.Revoke,
+            pluginAddr,
+            address(dao),
+            address(0),
+            SET_METADATA_PERMISSION_ID
+        );
+        _assertPermission(
+            permissions[4],
+            PermissionLib.Operation.Revoke,
+            pluginAddr,
+            ANY_ADDR,
+            address(0),
+            CREATE_PROPOSAL_PERMISSION_ID
+        );
+        _assertPermission(
+            permissions[5],
+            PermissionLib.Operation.Revoke,
+            pluginAddr,
+            ANY_ADDR,
+            address(0),
+            EXECUTE_PROPOSAL_PERMISSION_ID
+        );
+    }
+
+    function test_WhenCallingPrepareUninstallationAndHelpersContainAGovernanceERC20Token()
+        external
+        givenTheContextIsPrepareUninstallation
+    {
+        // It correctly returns permissions, when the required number of helpers is supplied
+        address pluginAddr = makeAddr("plugin");
+        address conditionAddr = makeAddr("condition");
+        GovernanceERC20 govToken = new GovernanceERC20(IDAO(address(dao)), "G", "G", defaultMintSettings);
+
+        address[] memory helpers = new address[](2);
+        helpers[0] = conditionAddr;
+        helpers[1] = address(govToken);
+
+        IPluginSetup.SetupPayload memory payload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: helpers, data: ""});
+
+        PermissionLib.MultiTargetPermission[] memory permissions =
+            pluginSetup.prepareUninstallation(address(dao), payload);
+
+        // The list of permissions to revoke is identical regardless of the token type.
+        assertEq(permissions.length, 6);
+        _assertPermission(
+            permissions[0],
+            PermissionLib.Operation.Revoke,
+            pluginAddr,
+            address(dao),
+            address(0),
+            UPDATE_VOTING_SETTINGS_PERMISSION_ID
+        );
+    }
+
+    function _encodeInstallData(
+        MajorityVotingBase.VotingSettings memory _votingSettings,
+        PluginSetupContract.TokenSettings memory _tokenSettings,
+        GovernanceERC20.MintSettings memory _mintSettings,
+        IPlugin.TargetConfig memory _targetConfig,
+        uint256 _minApproval,
+        bytes memory _metadata
+    ) internal pure returns (bytes memory) {
+        return abi.encode(_votingSettings, _tokenSettings, _mintSettings, _targetConfig, _minApproval, _metadata);
+    }
+
+    function test_failsIfDataIsEmptyOrNotOfMinLength() external givenTheContextIsPrepareInstallation {
+        bytes memory data = "";
+        vm.expectRevert();
+        pluginSetup.prepareInstallation(address(dao), data);
+
+        data = hex"000000"; // not min length
+        vm.expectRevert();
+        pluginSetup.prepareInstallation(address(dao), data);
+    }
+
+    function test_failsIfMintSettingsArraysDoNotHaveTheSameLength() external givenTheContextIsPrepareInstallation {
+        address[] memory receivers = new address[](1);
+        receivers[0] = alice;
+        defaultMintSettings.receivers = receivers;
+        defaultMintSettings.amounts = new uint256[](2); // Mismatch
+
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                GovernanceERC20.MintSettingsArrayLengthMismatch.selector,
+                receivers.length,
+                defaultMintSettings.amounts.length
+            )
+        );
+        pluginSetup.prepareInstallation(address(dao), installData);
+    }
+
+    function test_failsIfPassedTokenAddressIsNotAContract() external givenTheContextIsPrepareInstallation {
+        defaultTokenSettings.addr = alice; // EOA, not a contract
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        vm.expectRevert();
+        pluginSetup.prepareInstallation(address(dao), installData);
+    }
+
+    function test_failsIfPassedTokenAddressIsNotERC20() external givenTheContextIsPrepareInstallation {
+        // DAO contract is not an ERC20 token
+        defaultTokenSettings.addr = address(dao);
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        vm.expectRevert();
+        pluginSetup.prepareInstallation(address(dao), installData);
+    }
+
+    function test_correctlyReturnsPluginHelpersAndPermissions_whenAnERC20TokenAddressIsSupplied()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        ERC20Mock erc20 = new ERC20Mock("Test", "TST");
+        defaultTokenSettings.addr = address(erc20);
+
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        (address plugin, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), installData);
+
+        assertTrue(plugin != address(0));
+        assertEq(prepared.helpers.length, 2, "Should have 2 helpers (Condition, GovernanceWrappedERC20)");
+        assertEq(prepared.permissions.length, 6, "Should have 6 permissions");
+    }
+
+    function test_correctlySetsUpGovernanceWrappedERC20Helper_whenAnERC20TokenAddressIsSupplied()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        ERC20Mock erc20 = new ERC20Mock("Test", "TST");
+        defaultTokenSettings.addr = address(erc20);
+
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        (, IPluginSetup.PreparedSetupData memory prepared) = pluginSetup.prepareInstallation(address(dao), installData);
+
+        assertEq(prepared.helpers.length, 2, "Should have 2 helpers (Condition, GovernanceWrappedERC20)");
+        address helperAddr = prepared.helpers[1];
+        GovernanceWrappedERC20 wrappedToken = GovernanceWrappedERC20(helperAddr);
+
+        assertEq(address(wrappedToken.underlying()), address(erc20), "Underlying token should match");
+        assertEq(wrappedToken.name(), defaultTokenSettings.name, "Wrapped token name should match");
+        assertEq(wrappedToken.symbol(), defaultTokenSettings.symbol, "Wrapped token symbol should match");
+    }
+
+    function test_correctlyReturnsPluginHelpersAndPermissions_whenAGovernanceTokenAddressIsSupplied()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        (,, IVotesUpgradeable govToken,) = new SimpleBuilder().build();
+        defaultTokenSettings.addr = address(govToken);
+
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        (address plugin, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), installData);
+
+        assertTrue(plugin != address(0));
+        assertEq(prepared.helpers.length, 2, "Should have 2 helpers");
+        assertEq(prepared.permissions.length, 6, "Should have 6 permissions");
+    }
+
+    function test_correctlyReturnsPluginHelpersAndPermissions_whenATokenAddressIsNotSupplied()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        defaultTokenSettings.addr = address(0);
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        (address plugin, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), installData);
+
+        assertTrue(plugin != address(0));
+        assertEq(prepared.helpers.length, 2, "Should have 2 helpers");
+        assertEq(prepared.permissions.length, 7, "Should have 7 permissions (including MINT)");
+    }
+
+    function test_correctlySetsUpThePluginAndHelpers_whenATokenAddressIsNotPassed()
+        external
+        givenTheContextIsPrepareInstallation
+    {
+        defaultTokenSettings.addr = address(0);
+        address[] memory receivers = new address[](2);
+        receivers[0] = alice;
+        receivers[1] = bob;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 100 ether;
+        amounts[1] = 200 ether;
+        defaultMintSettings.receivers = receivers;
+        defaultMintSettings.amounts = amounts;
+
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        (address pluginAddr, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), installData);
+
+        assertEq(prepared.helpers.length, 2, "Should have 2 helpers (Condition, GovernanceERC20)");
+
+        address helperAddr = prepared.helpers[1];
+        GovernanceERC20 newToken = GovernanceERC20(helperAddr);
+        TokenVoting plugin = TokenVoting(pluginAddr);
+
+        assertEq(newToken.name(), defaultTokenSettings.name, "New token name should match");
+        assertEq(newToken.symbol(), defaultTokenSettings.symbol, "New token symbol should match");
+        assertEq(address(plugin.getVotingToken()), helperAddr, "Plugin should point to the new token");
+    }
+
+    function test_returnsThePermissionsExpectedForTheUpdateFromBuild1() external givenTheContextIsPrepareUpdate {
+        (, TokenVoting plugin,,) = new SimpleBuilder().build();
+        address pluginAddr = address(plugin);
+        bytes memory updateInnerData =
+            abi.encode(uint256(0), IPlugin.TargetConfig(address(0), IPlugin.Operation.Call), "");
+        IPluginSetup.SetupPayload memory updatePayload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: new address[](2), data: updateInnerData});
+
+        (bytes memory initData, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareUpdate(address(dao), 1, updatePayload);
+
+        assertEq(initData.length, 260);
+        assertEq(prepared.helpers.length, 1);
+        assertEq(prepared.permissions.length, 5); // 1 revoke, 4 grants
+    }
+
+    function test_returnsThePermissionsExpectedForTheUpdateFromBuild2() external givenTheContextIsPrepareUpdate {
+        (, TokenVoting plugin,,) = new SimpleBuilder().build();
+        address pluginAddr = address(plugin);
+        bytes memory updateInnerData =
+            abi.encode(uint256(0), IPlugin.TargetConfig(address(0), IPlugin.Operation.Call), "");
+        IPluginSetup.SetupPayload memory updatePayload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: new address[](2), data: updateInnerData});
+
+        (bytes memory initData, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareUpdate(address(dao), 2, updatePayload);
+
+        assertTrue(initData.length > 0);
+        assertEq(prepared.helpers.length, 1); // VotingPowerCondition
+        assertEq(prepared.permissions.length, 5); // 1 revoke, 4 grants
+    }
+
+    function test_returnsThePermissionsExpectedForTheUpdateFromBuild3() external givenTheContextIsPrepareUpdate {
+        (, TokenVoting plugin,,) = new SimpleBuilder().build();
+        address pluginAddr = address(plugin);
+        bytes memory updateInnerData =
+            abi.encode(uint256(0), IPlugin.TargetConfig(address(0), IPlugin.Operation.Call), "");
+        IPluginSetup.SetupPayload memory updatePayload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: new address[](2), data: updateInnerData});
+
+        (bytes memory initData, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareUpdate(address(dao), 3, updatePayload);
+
+        assertEq(initData.length, 0);
+        assertEq(prepared.helpers.length, 0);
+        assertEq(prepared.permissions.length, 0);
+    }
+
+    function test_correctlyReturnsPermissions_whenUninstallationAndHelpersContainGovernanceWrappedERC20()
+        external
+        givenTheContextIsPrepareUninstallation
+    {
+        (, TokenVoting plugin,,) = new SimpleBuilder().build();
+        address pluginAddr = address(plugin);
+        address[] memory helpers = new address[](1);
+        helpers[0] = address(governanceWrappedERC20Base);
+
+        IPluginSetup.SetupPayload memory payload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: helpers, data: ""});
+
+        PermissionLib.MultiTargetPermission[] memory permissions =
+            pluginSetup.prepareUninstallation(address(dao), payload);
+
+        assertEq(permissions.length, 6, "Should revoke 6 permissions");
+    }
+
+    function test_correctlyReturnsPermissions_whenUninstallationAndHelpersContainGovernanceERC20()
+        external
+        givenTheContextIsPrepareUninstallation
+    {
+        (, TokenVoting plugin,,) = new SimpleBuilder().build();
+        address pluginAddr = address(plugin);
+        address[] memory helpers = new address[](1);
+        helpers[0] = address(governanceERC20Base);
+
+        IPluginSetup.SetupPayload memory payload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: helpers, data: ""});
+
+        PermissionLib.MultiTargetPermission[] memory permissions =
+            pluginSetup.prepareUninstallation(address(dao), payload);
+
+        assertEq(permissions.length, 6, "Should revoke 6 permissions");
+    }
+
+    modifier givenTheInstallationParametersAreDefined() {
+        address[] memory receivers = new address[](2);
+        receivers[0] = alice;
+        receivers[1] = bob;
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 100e18;
+        amounts[1] = 200e18;
+        defaultMintSettings = GovernanceERC20.MintSettings(receivers, amounts);
+        _;
+    }
+
+    function test_WhenCallingEncodeInstallationParametersWithTheParameters()
+        external
+        givenTheInstallationParametersAreDefined
+    {
+        bytes memory encodedData = pluginSetup.encodeInstallationParameters(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        bytes memory expectedData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        assertEq(encodedData, expectedData, "Encoded data does not match expected ABI encoding");
+    }
+
+    function test_WhenCallingDecodeInstallationParametersWithTheEncodedData()
+        external
+        givenTheInstallationParametersAreDefined
+    {
+        bytes memory encodedData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+
+        (
+            MajorityVotingBase.VotingSettings memory votingSettings,
+            PluginSetupContract.TokenSettings memory tokenSettings,
+            GovernanceERC20.MintSettings memory mintSettings,
+            IPlugin.TargetConfig memory targetConfig,
+            uint256 minApproval,
+            bytes memory metadata
+        ) = pluginSetup.decodeInstallationParameters(encodedData);
+
+        assertEq(uint8(votingSettings.votingMode), uint8(defaultVotingSettings.votingMode));
+        assertEq(votingSettings.supportThreshold, defaultVotingSettings.supportThreshold);
+        assertEq(votingSettings.minParticipation, defaultVotingSettings.minParticipation);
+        assertEq(tokenSettings.addr, defaultTokenSettings.addr);
+        assertEq(tokenSettings.name, defaultTokenSettings.name);
+        assertEq(tokenSettings.symbol, defaultTokenSettings.symbol);
+        assertEq(mintSettings.receivers.length, defaultMintSettings.receivers.length);
+        assertEq(mintSettings.receivers[0], defaultMintSettings.receivers[0]);
+        assertEq(mintSettings.amounts[1], defaultMintSettings.amounts[1]);
+        assertEq(targetConfig.target, defaultTargetConfig.target);
+        assertEq(uint256(targetConfig.operation), uint256(defaultTargetConfig.operation));
+        assertEq(minApproval, defaultMinApproval);
+        assertEq(metadata, defaultMetadata);
+    }
+
+    modifier givenTheInstallationRequestIsForANewToken() {
+        defaultTokenSettings.addr = address(0);
+        address[] memory receivers = new address[](1);
+        receivers[0] = alice;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1 ether;
+        defaultMintSettings = GovernanceERC20.MintSettings(receivers, amounts);
+        _;
+    }
+
+    function test_WhenCallingPrepareInstallation_shouldReturnCorrectPermissionsForNewToken()
+        external
+        givenTheInstallationRequestIsForANewToken
+    {
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+        (, IPluginSetup.PreparedSetupData memory prepared) = pluginSetup.prepareInstallation(address(dao), installData);
+        assertEq(
+            prepared.permissions.length,
+            7,
+            "Should return exactly 7 permissions to be granted, including one for minting"
+        );
+    }
+
+    modifier givenTheInstallationRequestIsForAnExistingIVotescompliantToken() {
+        (,, IVotesUpgradeable govToken,) = new SimpleBuilder().build();
+        defaultTokenSettings.addr = address(govToken);
+        _;
+    }
+
+    function test_WhenCallingPrepareInstallation_shouldReturnCorrectPermissionsForExistingToken()
+        external
+        givenTheInstallationRequestIsForAnExistingIVotescompliantToken
+    {
+        bytes memory installData = _encodeInstallData(
+            defaultVotingSettings,
+            defaultTokenSettings,
+            defaultMintSettings,
+            defaultTargetConfig,
+            defaultMinApproval,
+            defaultMetadata
+        );
+        (address plugin, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareInstallation(address(dao), installData);
+        assertTrue(plugin != address(0));
+        assertEq(prepared.helpers.length, 2);
+        assertEq(
+            prepared.permissions.length,
+            6,
+            "Should return exactly 6 permissions to be granted and NOT deploy a new token"
+        );
+    }
+
+    modifier givenAPluginIsBeingUpdatedFromABuildVersionLessThan3() {
+        // This modifier is intentionally left empty for clarity in test definitions.
+        _;
+    }
+
+    function test_WhenCallingPrepareUpdateWithFromBuild2_returnsCorrectDataAndPermissions()
+        external
+        givenAPluginIsBeingUpdatedFromABuildVersionLessThan3
+    {
+        (, TokenVoting plugin,,) = new SimpleBuilder().build();
+        address pluginAddr = address(plugin);
+        address[] memory currentHelpers = new address[](2);
+
+        bytes memory updateInnerData =
+            abi.encode(uint256(2), IPlugin.TargetConfig(address(dao), IPlugin.Operation.Call), "");
+        IPluginSetup.SetupPayload memory updatePayload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: currentHelpers, data: updateInnerData});
+
+        (bytes memory initData, IPluginSetup.PreparedSetupData memory prepared) =
+            pluginSetup.prepareUpdate(address(dao), 2, updatePayload);
+
+        assertTrue(initData.length > 0, "Should return init data for update");
+        assertEq(prepared.helpers.length, 1, "Should return a new VotingPowerCondition helper");
+        assertEq(prepared.permissions.length, 5, "Should return 5 permission changes (1 revoke and 4 grants)");
+    }
+
+    modifier givenAPluginIsBeingUninstalled() {
+        address[] memory helpers = new address[](1);
+        // Simulate a new token installation to get a helper address.
+        // The address itself is what matters for the uninstallation logic branch.
+        helpers[0] = address(governanceERC20Base);
+        vm.store(address(pluginSetup), bytes32(uint256(uint160(address(dao)))), bytes32(uint256(uint160(helpers[0]))));
+        _;
+    }
+
+    function test_WhenCallingPrepareUninstallation_returnsCorrectPermissions() external {
+        (, TokenVoting plugin,,) = new SimpleBuilder().build();
+        address pluginAddr = address(plugin);
+        address[] memory helpers = new address[](1);
+        helpers[0] = address(new GovernanceERC20(dao, "T", "T", defaultMintSettings));
+
+        IPluginSetup.SetupPayload memory payload =
+            IPluginSetup.SetupPayload({plugin: pluginAddr, currentHelpers: helpers, data: ""});
+
+        PermissionLib.MultiTargetPermission[] memory permissions =
+            pluginSetup.prepareUninstallation(address(dao), payload);
+
+        assertEq(permissions.length, 6, "Should return exactly 6 permissions to be revoked");
+
+        helpers[0] = address(new GovernanceWrappedERC20(IERC20Upgradeable(address(new ERC20Mock("", ""))), "WT", "WT"));
+        permissions = pluginSetup.prepareUninstallation(address(dao), payload);
+        assertEq(permissions.length, 6, "Should return exactly 6 permissions to be revoked");
+    }
+
+    modifier givenATokenContractThatImplementsTheIVotesInterfaceFunctions() {
+        // This modifier is intentionally left empty for clarity in test definitions.
+        _;
+    }
+
+    function test_WhenCallingSupportsIVotesInterfaceWithAnIVotesToken_returnsTrue() external {
+        (,, IVotesUpgradeable govToken,) = new SimpleBuilder().build();
+        assertTrue(pluginSetup.supportsIVotesInterface(address(govToken)));
+    }
+
+    modifier givenATokenContractThatDoesNotImplementTheIVotesInterfaceFunctions() {
+        // This modifier is intentionally left empty for clarity in test definitions.
+        _;
+    }
+
+    function test_WhenCallingSupportsIVotesInterfaceWithANonIVotesToken_returnsFalse() external {
+        ERC20Mock nonVotesToken = new ERC20Mock("Test", "TST");
+        assertFalse(pluginSetup.supportsIVotesInterface(address(nonVotesToken)));
+    }
+
+    // modifier givenTheInstallationParametersAreDefined() {
+    //     _;
+    // }
+
+    // function test_WhenCallingEncodeInstallationParametersWithTheParameters()
+    //     external
+    //     givenTheInstallationParametersAreDefined
+    // {
+    //     // It Should return the correct ABI-encoded byte representation
+    //     vm.skip(true);
+    // }
+
+    // function test_WhenCallingDecodeInstallationParametersWithTheEncodedData()
+    //     external
+    //     givenTheInstallationParametersAreDefined
+    // {
+    //     // It Should return the original installation parameters
+    //     vm.skip(true);
+    // }
+
+    // modifier givenTheInstallationRequestIsForANewToken() {
+    //     _;
+    // }
+
+    // function test_WhenCallingPrepareInstallation() external givenTheInstallationRequestIsForANewToken {
+    //     // It Should return exactly 7 permissions to be granted, including one for minting
+    //     vm.skip(true);
+    // }
+
+    // modifier givenTheInstallationRequestIsForAnExistingIVotescompliantToken() {
+    //     _;
+    // }
+
+    // function test_WhenCallingPrepareInstallation2()
+    //     external
+    //     givenTheInstallationRequestIsForAnExistingIVotescompliantToken
+    // {
+    //     // It Should return exactly 6 permissions to be granted and NOT deploy a new token
+    //     vm.skip(true);
+    // }
+
+    // modifier givenAPluginIsBeingUpdatedFromABuildVersionLessThan3() {
+    //     _;
+    // }
+
+    // function test_WhenCallingPrepareUpdateWithFromBuild2()
+    //     external
+    //     givenAPluginIsBeingUpdatedFromABuildVersionLessThan3
+    // {
+    //     // It Should return the initData for the update and a new VotingPowerCondition helper
+    //     // It Should return 5 permission changes (1 revoke and 4 grants)
+    //     vm.skip(true);
+    // }
+
+    // modifier givenAPluginIsBeingUninstalled() {
+    //     _;
+    // }
+
+    // function test_WhenCallingPrepareUninstallation() external givenAPluginIsBeingUninstalled {
+    //     // It Should return exactly 6 permissions to be revoked
+    //     vm.skip(true);
+    // }
+
+    // modifier givenATokenContractThatImplementsTheIVotesInterfaceFunctions() {
+    //     _;
+    // }
+
+    // function test_WhenCallingSupportsIVotesInterfaceWithTheTokensAddress()
+    //     external
+    //     givenATokenContractThatImplementsTheIVotesInterfaceFunctions
+    // {
+    //     // It Should return true
+    //     vm.skip(true);
+    // }
+
+    // modifier givenATokenContractThatDoesNotImplementTheIVotesInterfaceFunctions() {
+    //     _;
+    // }
+
+    // function test_WhenCallingSupportsIVotesInterfaceWithTheTokensAddress2()
+    //     external
+    //     givenATokenContractThatDoesNotImplementTheIVotesInterfaceFunctions
+    // {
+    //     // It Should return false
+    //     vm.skip(true);
+    // }
+}

--- a/test/TokenVotingSetupZkSync.t.yaml
+++ b/test/TokenVotingSetupZkSync.t.yaml
@@ -1,0 +1,102 @@
+TokenVotingSetupZkSyncTest:
+  - when: Calling supportsInterface('0xffffffff')
+    then:
+      - it: does not support the empty interface
+  - when: Calling governanceERC20Base() and governanceWrappedERC20Base() after initialization
+    comment: This test is skipped if the network is ZkSync
+    then:
+      - it: stores the bases provided through the constructor
+  - given: The context is prepareInstallation
+    and:
+      - when: Calling prepareInstallation with data that is empty or not of minimum length
+        then:
+          - it: fails if data is empty, or not of minimum length
+      - when: Calling prepareInstallation if `MintSettings` arrays do not have the same length
+        then:
+          - it: fails if `MintSettings` arrays do not have the same length
+      - when: Calling prepareInstallation if passed token address is not a contract
+        then:
+          - it: fails if passed token address is not a contract
+      - when: Calling prepareInstallation if passed token address is not ERC20
+        then:
+          - it: fails if passed token address is not ERC20
+      - when: Calling prepareInstallation and an ERC20 token address is supplied
+        then:
+          - it: correctly returns plugin, helpers and permissions, when an ERC20 token address is supplied
+      - when: Calling prepareInstallation and an ERC20 token address is supplied
+        then:
+          - it: correctly sets up `GovernanceWrappedERC20` helper, when an ERC20 token address is supplied
+      - when: Calling prepareInstallation and a governance token address is supplied
+        then:
+          - it: correctly returns plugin, helpers and permissions, when a governance token address is supplied
+      - when: Calling prepareInstallation and a token address is not supplied
+        then:
+          - it: correctly returns plugin, helpers and permissions, when a token address is not supplied
+      - when: Calling prepareInstallation and a token address is not passed
+        then:
+          - it: correctly sets up the plugin and helpers, when a token address is not passed
+  - given: The context is prepareUpdate
+    and:
+      - when: Calling prepareUpdate for an update from build 1
+        then:
+          - it: returns the permissions expected for the update from build 1
+      - when: Calling prepareUpdate for an update from build 2
+        then:
+          - it: returns the permissions expected for the update from build 2
+      - when: Calling prepareUpdate for an update from build 3
+        then:
+          - it: returns the permissions expected for the update from build 3 (empty list)
+  - given: The context is prepareUninstallation
+    and:
+      - when: Calling prepareUninstallation and helpers contain a GovernanceWrappedERC20 token
+        then:
+          - it: correctly returns permissions, when the required number of helpers is supplied
+      - when: Calling prepareUninstallation and helpers contain a GovernanceERC20 token
+        then:
+          - it: correctly returns permissions, when the required number of helpers is supplied
+  - given: The installation parameters are defined
+    and:
+      - when: Calling encodeInstallationParameters() with the parameters
+        then:
+          - it: Should return the correct ABI-encoded byte representation
+      - when: Calling decodeInstallationParameters() with the encoded data
+        then:
+          - it: Should return the original installation parameters
+
+  - given: The installation request is for a new token
+    comment: The token address in TokenSettings is address(0)
+    and:
+      - when: Calling prepareInstallation()
+        then:
+          - it: Should return exactly 7 permissions to be granted, including one for minting
+
+  - given: The installation request is for an existing IVotes-compliant token
+    and:
+      - when: Calling prepareInstallation()
+        then:
+          - it: Should return exactly 6 permissions to be granted and NOT deploy a new token
+
+  - given: A plugin is being updated from a build version less than 3
+    and:
+      - when: Calling prepareUpdate() with _fromBuild = 2
+        then:
+          - it: Should return the initData for the update and a new VotingPowerCondition helper
+          - it: Should return 5 permission changes (1 revoke and 4 grants)
+
+  - given: A plugin is being uninstalled
+    and:
+      - when: Calling prepareUninstallation()
+        then:
+          - it: Should return exactly 6 permissions to be revoked
+
+  - given: A token contract that implements the IVotes interface functions
+    and:
+      - when: Calling supportsIVotesInterface() with the token's address
+        then:
+          - it: Should return true
+
+  - given: A token contract that does not implement the IVotes interface functions
+    and:
+      - when: Calling supportsIVotesInterface() with the token's address
+        then:
+          - it: Should return false


### PR DESCRIPTION
This PR:
- Adds `encodeInstallationParams()` and `decodeInstallationParams()`
  - `encodeInstallationParams()` can now be easily called by any UI preparing a plugin
  - Single source of truth, no more reverse engineering and manual encoding
- Adds the new tests for it
- Adds tests that were missing on the HH implementation