### PR TITLE
Fix incorrect gap size

### DIFF
--- a/src/TokenVoting.sol
+++ b/src/TokenVoting.sol
@@ -369,5 +369,5 @@ contract TokenVoting is IMembership, MajorityVotingBase {
     /// @dev This empty reserved space is put in place to allow future versions to add new
     /// variables without shifting down storage in the inheritance chain.
     /// https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-    uint256[48] private __gap;
+    uint256[47] private __gap;
 }


### PR DESCRIPTION
Adding Enumerable set in TokenVoting takes two slots, not just one. 
Fork and upgradeability tests can't catch this situation because the variable appears on the last contract of the inheritance chain.