### PR TITLE
Ensuring that hasSucceeded returns the appropriate value

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -384,6 +384,7 @@ TokenVotingTest
 │   │       └── It Should assume a block number indexing
 │   ├── When Calling initialize with a list of excluded accounts
 │   │   ├── It Should correctly add all provided addresses to the excludedAccounts set
+│   │   ├── It Should emit an event
 │   │   └── It Should allow an empty list of excluded accounts
 │   └── When Calling initialize with duplicate addresses in the excluded accounts list
 │       └── It Should store each address only once in the excludedAccounts set
@@ -495,6 +496,9 @@ TokenVotingTest
 │   │   └── It does not execute early when voting with the `tryEarlyExecution` option
 │   ├── When Trying to execute a proposal that is not yet decided
 │   │   └── It reverts if vote is not decided yet
+│   ├── When The proposal passed but didnt finish yet
+│   │   ├── It hasSucceeded returns false
+│   │   └── It can not execute
 │   └── When The caller does not have EXECUTEPROPOSALPERMISSIONID
 │       └── It can not execute even if participation and support are met when caller does not have permission
 ├── Given In the Early Execution Voting Mode

--- a/src/base/MajorityVotingBase.sol
+++ b/src/base/MajorityVotingBase.sol
@@ -604,15 +604,13 @@ abstract contract MajorityVotingBase is
         Proposal storage proposal_ = proposals[_proposalId];
 
         if (_isOpen) {
-            // If the proposal is still open and the voting mode is VoteReplacement,
-            // success cannot be determined until the voting period ends.
-            if (proposal_.parameters.votingMode == VotingMode.VoteReplacement) {
+            // If the proposal is still open and the voting mode is not EarlyExecution,
+            // success cannot be determined.
+            if (proposal_.parameters.votingMode != VotingMode.EarlyExecution) {
                 return false;
             }
-
-            // For Standard and EarlyExecution modes, check if the support threshold
-            // has been reached early to determine success while proposal is still open.
-            if (!isSupportThresholdReachedEarly(_proposalId)) {
+            // For EarlyExecution, check if the support threshold has been reached early.
+            else if (!isSupportThresholdReachedEarly(_proposalId)) {
                 return false;
             }
         } else {

--- a/test/TokenVoting.t.yaml
+++ b/test/TokenVoting.t.yaml
@@ -198,6 +198,10 @@ TokenVotingTest:
       - when: Trying to execute a proposal that is not yet decided
         then:
           - it: reverts if vote is not decided yet
+      - when: The proposal passed but didn't finish yet
+        then:
+          - it: hasSucceeded returns false
+          - it: can not execute
       - when: The caller does not have EXECUTE_PROPOSAL_PERMISSION_ID
         then:
           - it: can not execute even if participation and support are met when caller does not have permission


### PR DESCRIPTION
Ensuring that hasSucceeded returns false, even when a standard voting proposal succeeds before endDate